### PR TITLE
Fetch images from inside of Makehuman module

### DIFF
--- a/exts/omni.makehuman/omni/makehuman/mhcaller.py
+++ b/exts/omni.makehuman/omni/makehuman/mhcaller.py
@@ -356,4 +356,4 @@ def modifier_image(name : str):
     # Return the modifier path based on the modifier name
     # TODO determine if images can be loaded from the Makehuman module stored in
     # site-packages so we don't have to include the data twice
-    return os.path.dirname(inspect.getfile(makehuman)) + "/" + targets.getTargets().images.get(name, name)
+    return os.path.join(os.path.dirname(inspect.getfile(makehuman)),targets.getTargets().images.get(name, name))


### PR DESCRIPTION
Modifier label images are retrieved from inside the makehuman install so we don't have to download them twice